### PR TITLE
OCP-1781: Fix filebeat v6 handler

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,14 +1,14 @@
 ---
 
-- name: Validate filebeat config
+- name: Validate filebeat config v5
   shell: >
-    if [[ -f {{ filebeat_bin_dir }}/filebeat.sh ]] ; then
         {{ filebeat_bin_dir }}/filebeat.sh \
         -c {{ filebeat_conf_dir }}/filebeat.yml \
         -e -configtest
-    else
+
+- name: Validate filebeat config v6
+  shell: >
         {{ filebeat_bin_dir }}/filebeat test config
-    fi
 
 - name: Restart filebeat
   service: name=filebeat state=restarted

--- a/tasks/install-debian.yml
+++ b/tasks/install-debian.yml
@@ -11,10 +11,21 @@
     update_cache: yes
     state:        present
 
-- name: Install filebeat
+- name: Install filebeat v5
   apt: 
     name:  "filebeat={{ filebeat_version|default('*') }}"
     state: present
   notify:
-    - Validate filebeat config
+    - Validate filebeat config v5
     - Restart filebeat
+  when: filebeat_major_version == "5"
+
+
+- name: Install filebeat v6
+  apt:
+    name:  "filebeat={{ filebeat_version|default('*') }}"
+    state: present
+  notify:
+    - Validate filebeat config v6
+    - Restart filebeat
+  when: filebeat_major_version == "6"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,7 +38,7 @@
     src:  logging_frag.yml.j2 
     dest: "{{ filebeat_conf_fragments_dir }}/40-logging.yml"
 
-- name: Create filebeat config file from assembled config fragments
+- name: Create filebeat config file from assembled config fragments v5
   assemble: 
     src:   "{{ filebeat_conf_fragments_dir }}" 
     dest:  "{{ filebeat_conf_dir }}/filebeat.yml"
@@ -46,8 +46,21 @@
     group: root
     mode:  0644
   notify:
-    - Validate filebeat config
+    - Validate filebeat config v5
     - Restart filebeat
+  when: filebeat_major_version == "5"
+
+- name: Create filebeat config file from assembled config fragments v6
+  assemble:
+    src:   "{{ filebeat_conf_fragments_dir }}"
+    dest:  "{{ filebeat_conf_dir }}/filebeat.yml"
+    owner: root
+    group: root
+    mode:  0644
+  notify:
+    - Validate filebeat config v6
+    - Restart filebeat
+  when: filebeat_major_version == "6"
 
 - name: Start filebeat
   service: name=filebeat enabled=yes state=started


### PR DESCRIPTION
Ansible seems to reject the if clause in the shell statement.

I split out the handlers, so there are different configuration
validation handlers for filebeat v5 and v6. Then, I call the appropriate
handler based on which filebeat we are installing.